### PR TITLE
Fixes typo in cache clean controller & cache model

### DIFF
--- a/Controller/Adminhtml/Cache/CleanResizedImages.php
+++ b/Controller/Adminhtml/Cache/CleanResizedImages.php
@@ -62,7 +62,7 @@ class CleanResizedImages extends MagentoAdminCache
     public function execute(): Redirect
     {
         try {
-            $this->resizerCache->clearResizedImagesCache();
+            $this->resizeCache->clearResizedImagesCache();
             $this->_eventManager->dispatch('web200_imageresize_clean_images_cache_after');
             $this->messageManager->addSuccessMessage(__('The resized images cache was cleaned.'));
         } catch (LocalizedException $e) {

--- a/Model/Cache.php
+++ b/Model/Cache.php
@@ -40,6 +40,6 @@ class Cache
      */
     public function clearResizedImagesCache(): void
     {
-        $this->mediaDirectory->delete(Resizer::IMAGE_RESIZE_CACHE_DIR);
+        $this->mediaDirectory->delete(Resize::IMAGE_RESIZE_CACHE_DIR);
     }
 }


### PR DESCRIPTION
There is a typo in the cache clean controller and the cache model that causes an undefined property error / undefined class error and causes the cache cleaning to fail when initiated from the admin cache management panel.